### PR TITLE
Only use rust-htslib/curl when `curl` feature is enabled.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ fffx = { version = "0.1.3", optional = true }
 # Dep for development
 #minimap2-sys = { path = "./minimap2-sys" }
 minimap2-sys = "0.1.16"
-rust-htslib = { version = "0.44.1", optional = true }
+rust-htslib = { version = "0.44.1", default-features = false, optional = true }
 
 # [profile.release]
 # opt-level = 3
@@ -50,14 +50,15 @@ rust-htslib = { version = "0.44.1", optional = true }
 opt-level = 3
 
 [features]
-default = ["map-file"]
+default = ["map-file", "curl"]
 mm2-fast = ["minimap2-sys/mm2-fast"]
 sse2only = ["minimap2-sys/sse2only"]
 htslib = ['rust-htslib']
 simde = ["minimap2-sys/simde"]
 map-file = ["fffx", "simdutf8"]
 zlib-ng = ["minimap2-sys/zlib-ng"]
-static = ["minimap2-sys/static"]
+curl = ["rust-htslib/curl"]
+static = ["minimap2-sys/static", "rust-htslib/static"]
 
 [package.metadata.docs.rs]
 features = ["map-file", "htslib"]


### PR DESCRIPTION
`rust-htslib` is pulling in curl by default; this PR disables default features on rust-htslib and enables `curl` only if `curl` is selected as a feature of this crate.

It's pretty minor, but libcurl can be a tough dependency to manage.

Behavior should remain unchanged unless a user opts out by disabling default features for `minimap2-rs`.