### PR TITLE
Fixes memory leak due to sequences allocated by minimap2 not being freed

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,7 +48,6 @@ use std::cell::RefCell;
 
 use std::mem::MaybeUninit;
 use std::num::NonZeroI32;
-use std::ops::DerefMut;
 use std::path::Path;
 
 use std::os::unix::ffi::OsStrExt;


### PR DESCRIPTION
Switches `mm_idx` from being a struct back to a pointer for `Aligner` struct.

When rust takes ownership here, it doesn't actually get ownership since it just does a `Copy` of the struct but the data allocated by minimap2 still exists. 
https://github.com/jguhlin/minimap2-rs/blob/b0023633ede58a176cb4adeea2f468938d97bb53/src/lib.rs#L769

Even if you were to free the original pointer with `mm_idx_destroy` after that line, it would later segfault since `idx.seq` is just a pointer to the sequences allocated by minimap2 here: 
https://github.com/lh3/minimap2/blob/69e36299168d739dded1c5549f662793af10da83/index.c#L425

So I changed the struct back to a pointer and used the manual `Drop` `impl` to free the minimap2 index.

Thanks for the crate btw!