### PR TITLE
fix: cigar string missing softclip operation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -938,7 +938,7 @@ impl Aligner {
 
                             // Pre and append soft clip identifiers to start and end
                             if clip_len0 > 0 {
-                                cigar_str = format!("{}{}{}", clip_len0, cigar_str, clip_char);
+                                cigar_str = format!("{}{}{}", clip_len0, clip_char, cigar_str);
                                 if self.cigar_clipping {
                                     cigar.insert(0, (clip_len0 as u32, 4_u8));
                                 }


### PR DESCRIPTION
PR addresses a bug in the CIGAR string formatting where soft-clipping (S) at the start of a CIGAR string was concatenated in the wrong order, so any softclipped bases at the start of the CIGAR were being incorrectly added as an integer to the next operation (#73)

Minimap2:
`3S11232M9D10`

Before:
`cigar_str: Some("311232M9D10")`

After:
`cigar_str: Some("3S11232M9D10")`

Tested this against a hard copy of minimap2 + cargo test

Let me know what you think

Cheers