### PR TITLE
Better detection of supplementary alignments

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -887,7 +887,7 @@ impl Aligner {
                         (*((*(self.idx.unwrap())).seq.offset(reg.rid as isize))).name;
 
                     let is_primary = reg.parent == reg.id;
-                    let is_supplementary = (reg.parent == reg.id && !reg.sam_pri());
+                    let is_supplementary = (reg.parent == reg.id) && (reg.sam_pri() == 0);
 
                     // todo holy heck this code is ugly
                     let alignment = if !reg.p.is_null() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -557,9 +557,7 @@ impl Aligner {
 
     // Check options
     pub fn check_opts(&self) -> Result<(), &'static str> {
-        let result = unsafe {
-            mm_check_opt(&self.idxopt, &self.mapopt)
-        };
+        let result = unsafe { mm_check_opt(&self.idxopt, &self.mapopt) };
 
         if result == 0 {
             Ok(())
@@ -567,7 +565,6 @@ impl Aligner {
             Err("Invalid options")
         }
     }
-
 
     /// Set index parameters for minimap2 using builder pattern
     /// Creates the index as well with the given number of threads (set at struct creation).
@@ -890,8 +887,8 @@ impl Aligner {
                         (*((*(self.idx.unwrap())).seq.offset(reg.rid as isize))).name;
 
                     let is_primary = reg.parent == reg.id;
-                    let is_supplementary = reg.sam_pri() == 0;
-                    
+                    let is_supplementary = (reg.parent == reg.id && !reg.sam_pri());
+
                     // todo holy heck this code is ugly
                     let alignment = if !reg.p.is_null() {
                         let p = &*reg.p;
@@ -1492,9 +1489,7 @@ mod tests {
 
         aligner.check_opts().expect("Opts are invalid");
 
-        aligner = aligner
-            .with_index("test_data/genome.fa", None)
-            .unwrap();
+        aligner = aligner.with_index("test_data/genome.fa", None).unwrap();
 
         let output = aligner.map(
             b"GAAATACGGGTCTCTGGTTTGACATAAAGGTCCAACTGTAATAACTGATTTTATCTGTGGGTGATGCGTTTCTCGGACAACCACGACCGCGCCCAGACTTAAATCGCACATACTGCGTCGTGCAATGCCGGGCGCTAACGGCTCAATATCACGCTGCGTCACTATGGCTACCCCAAAGCGGGGGGGGCATCGACGGGCTGTTTGATTTGAGCTCCATTACCCTACAATTAGAACACTGGCAACATTTGGGCGTTGAGCGGTCTTCCGTGTCGCTCGATCCGCTGGAACTTGGCAACCACACTCTAAACTACATGTGGTATGGCTCATAAGATCATGCGGATCGTGGCACTGCTTTCGGCCACGTTAGAGCCGCTGTGCTCGAAGATTGGGACCTACCAAC",


### PR DESCRIPTION
This is related to [issue 72](https://github.com/jguhlin/minimap2-rs/issues/72).  Essentially, minimap2-rs is treating secondary alignments as supplementary, whereas they are quite different.

Unfortunately, the code where the supplementary alignment flag is set in minimap2 isn't super-elegant, I believe the most relevant part is [here](https://github.com/lh3/minimap2/blob/69e36299168d739dded1c5549f662793af10da83/format.c#L493).  I've made this change in this PR and it seems to work in my use case.  Note that I'm not handling the > 1 segment case here, so I believe we'll need further work to handle reads with > 1 segment (e.g. paired-end short reads).