### PR TITLE
Allow building the index from a file that is a named pipe

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -708,8 +708,8 @@ where
             return Err("Index File does not exist");
         }
 
-        // Confirm file is not empty
-        if path.as_ref().metadata().unwrap().len() == 0 {
+        // Confirm file is not empty if it is a regular file
+        if path.as_ref().is_file() && path.as_ref().metadata().unwrap().len() == 0 {
             return Err("Index File is empty");
         }
 
@@ -2270,7 +2270,7 @@ mod tests {
     #[test]
     fn mapopt_defaults() {
         let aligner = Aligner::builder().map_ont();
-        println!("{:#?}", aligner.mapopt);       
+        println!("{:#?}", aligner.mapopt);
 
         let aligner = Aligner::builder();
         println!("{:#?}", aligner.mapopt);


### PR DESCRIPTION
Hi @jguhlin,

  I have a need for a use-case where I need to build the minimap2 index from a file that is a named pipe.  The existing code doesn't allow this because it checks the size of the input file before attempting to build the index, but the named pipe has 0 size until the the reader (in this case, minimap2) opens the pipe.  I modified the code in `with_index` to only check the file size if the path passed in refers to a regular file.  Let me know if this looks OK to you; it's a very minor change.

Best,
Rob