### PR TITLE
fix segfault related to #128

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1109,8 +1109,6 @@ impl Aligner<Built> {
         };
 
         let mappings = BUF.with_borrow_mut(|buf| {
-            let km: *mut libc::c_void = unsafe { mm_tbuf_get_km(buf.get_buf()) };
-
             mm_reg = MaybeUninit::new(unsafe {
                 mm_map(
                     &**self.idx.as_ref().unwrap().as_ref() as *const mm_idx_t,
@@ -1124,6 +1122,8 @@ impl Aligner<Built> {
             });
 
             let mut mappings = Vec::with_capacity(n_regs as usize);
+
+            let km: *mut libc::c_void = unsafe { mm_tbuf_get_km(buf.get_buf()) };
 
             for i in 0..n_regs {
                 unsafe {


### PR DESCRIPTION
This needs some more (independent) validation, but this should fix the (long standing) segfault that previously was solved with the repeated `km_init` hack.

Essentially, the previous code was handing out multiple references (including a mutable one) to the underlying thread local buffer at the same time.  This voilates the rust shared xor mutable rules and, recalling that `unsafe` doesn't disable *the rules* and that we are still responsible for upholding them, I believe that opened us up to undefined behavior ultimately resulting in the segfault.

This PR applies an easy fix.  It simply moves the acquisition of the mutable pointer to the `km` object until after the call to `mm_map`, so that we only acquire the mutable reference after the lifetime of the `mm_map` call is finished with it.  In my testing, this seems to resolve the segfaults that were previously occurring.
