### PR TITLE
chore: add dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -5,15 +5,9 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    commit-message:
-      # Prefix all commit messages with "deps: "
-      prefix: "deps"
 
   # Update dependabot
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
-    commit-message:
-      # Prefix all commit messages with "deps: "
-      prefix: "deps"

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  # Update rust dependencies
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      # Prefix all commit messages with "deps: "
+      prefix: "deps"
+
+  # Update dependabot
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      # Prefix all commit messages with "deps: "
+      prefix: "deps"


### PR DESCRIPTION
- adds dependabot to update dependencies, which would help us maintaining downstream repos
- uses the pattern from [rust-htslib](https://github.com/rust-bio/rust-htslib/blob/master/.github/dependabot.yml), where the prefix used for dependabot PRs is `build(deps): `