### PR TITLE
addition of extended htslib

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,14 +34,14 @@ exclude = ["minimappers2", "fakeminimap2", "minimap2-sys"]
 [dependencies]
 libc = "0.2"
 needletail = { version = "0.6", optional = true, default-features = false}
-
-minimap2-sys = { path = "./minimap2-sys", version = "0.1.30+minimap2.2.30" }
 rust-htslib = { version = "1.0", default-features = false, optional = true }
+extended-htslib = { version = "0.3.0", default-features = false, optional = true }
+minimap2-sys = { path = "./minimap2-sys", version = "0.1.30+minimap2.2.30" }
 
 [dev-dependencies]
-rayon = "1.10"
+rayon = "1.12"
 crossbeam = "0.8.4"
-clap = { version = "4.5.40", features = ["derive"] }
+clap = { version = "4.6.1", features = ["derive"] }
 needletail = { version = "0.6", default-features = false}
 
 # The end-user should decide this...
@@ -54,13 +54,14 @@ needletail = { version = "0.6", default-features = false}
 # opt-level = 3
 
 [features]
-default = ["map-file"]
+default = ["map-file", "htslib"]
 map-file = ["needletail"]
 htslib = ['rust-htslib']
+extendedhtslib = ['extended-htslib']
 simde = ["minimap2-sys/simde"]
 zlib-ng = ["minimap2-sys/zlib-ng"]
-curl = ["rust-htslib/curl"]
-static = ["minimap2-sys/static", "rust-htslib/static"]
+curl = ["rust-htslib/curl", "extended-htslib/curl"]
+static = ["minimap2-sys/static", "rust-htslib/static", "extended-htslib/static"]
 sse2only = ["minimap2-sys/sse2only"]
 
 [package.metadata.docs.rs]

--- a/src/extendedhtslib.rs
+++ b/src/extendedhtslib.rs
@@ -1,0 +1,735 @@
+//! Provides an interface to minimap2 that returns rust_htslib::Records
+//!
+//!
+//! ```
+
+//! use minimap2::Aligner;
+//! use extended_htslib::bam::{Header, HeaderView};
+//! use extended_htslib::bam::record::Aux;
+//! let aligner = Aligner::builder()
+//!     .with_cigar()
+//!     .with_index("test_data/genome.fa", None)
+//!     .unwrap();
+//!
+//! let mut header = Header::new();
+//! aligner.populate_header(&mut header);
+//! let header_view = HeaderView::from_header(&header);
+//!
+//! let records = aligner
+//!     .map_to_sam(
+//!         b"TACGCCACACGGGCTACACTCTCGCCTTCTCGTCTCAACTACGAGATGGACTGTCGGCCTAGAGGATCTAACACGAGAAGTACTTGCCGGCAAGCCCTAA",
+//!         Some(b"2222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222"),
+//!         Some(b"read1"),
+//!         &header_view, None, None)
+//!     .unwrap();
+//!
+//! assert_eq!(records.len(), 1);
+//! let record = records.first().unwrap();
+//! assert_eq!((record.tid(), record.pos(), record.mapq()), (0, 180, 13));
+//!
+//! let nm = record.aux(b"NM").unwrap();
+//! assert_eq!(nm, Aux::U8(5));
+//!
+//! // you can also map reads with no quality/name
+//! let records = aligner
+//!     .map_to_sam(
+//!         b"TACGCCACACGGGCTACACTCTCGCCTTCTCGTCTCAACTACGAGATGGACTGTCGGCCTAGAGGATCTAACACGAGAAGTACTTGCCGGCAAGCCCTAA",
+//!         None, None,  &header_view, None, None)
+//!     .unwrap();
+//!
+//! assert_eq!(records.len(), 1);
+//! let record = records.first().unwrap();
+//! assert_eq!((record.tid(), record.pos(), record.mapq()), (0, 180, 13));
+//! ```
+
+use super::ffi as mm_ffi;
+use crate::{Aligner, BUF, Built, Mapping, Strand};
+use extended_htslib::bam::ext::{BamRecordExtensions, CgAlignedBlockPairs, CsData};
+use extended_htslib::bam::header::HeaderRecord;
+use extended_htslib::bam::record::{Aux, Cigar, CigarString, CsString};
+use extended_htslib::bam::{Header, HeaderView, Record};
+use minimap2_sys::{km_destroy, km_init};
+use std::ffi::{CStr, CString};
+use std::mem::MaybeUninit;
+use std::ptr;
+use std::str::FromStr;
+use std::sync::Arc;
+
+/// A wrapper around mm_bseq1_t
+#[derive(Debug)]
+pub struct Query {
+    pub inner: mm_ffi::mm_bseq1_t,
+}
+
+impl Query {
+    pub fn new(seq: &[u8], qual: Option<&[u8]>, name: Option<&[u8]>) -> Self {
+        let l_seq = seq.len();
+        assert!(l_seq > 0, "Empty sequence supplied");
+        // clone into a CString
+        let seq = CString::new(seq).unwrap().into_raw();
+        let qual = match qual {
+            Some(qual) => {
+                assert_eq!(
+                    l_seq,
+                    qual.len(),
+                    "Sequence and quality strings are different lenght"
+                );
+                CString::new(qual).unwrap().into_raw()
+            }
+            None => ptr::null_mut(),
+        };
+        let name = CString::new(name.unwrap_or(b"query")).unwrap();
+
+        let inner = mm_ffi::mm_bseq1_t {
+            l_seq: l_seq as i32,
+            rid: 0, // TODO: pass a unique read id,
+            name: name.into_raw(),
+            seq,
+            qual,
+            comment: ptr::null_mut(), // TODO: pass SAM flags in comment
+        };
+        Query { inner }
+    }
+
+    pub fn as_unmapped_record(&self) -> Record {
+        let mut rec = Record::new();
+
+        let qname = unsafe { CStr::from_ptr(self.inner.name).to_bytes() };
+        let seq = unsafe { CStr::from_ptr(self.inner.seq).to_bytes() };
+        let qual = if self.inner.qual.is_null() {
+            rec.set(qname, None, seq, &vec![255u8; seq.len()]);
+        } else {
+            rec.set(qname, None, seq, unsafe {
+                CStr::from_ptr(self.inner.qual).to_bytes()
+            });
+        };
+        rec.set_unmapped();
+        rec.set_tid(-1);
+        rec.set_pos(-1);
+        rec.set_mapq(0);
+        rec.set_mpos(-1);
+        rec.set_mtid(-1);
+        rec.set_insert_size(0);
+        rec
+    }
+}
+
+impl Aligner<Built> {
+    pub fn populate_header(&self, header: &mut Header) {
+        let mm_idx = MMIndex::from(self);
+        for seq in mm_idx.seqs() {
+            header.push_record(
+                HeaderRecord::new(b"SQ")
+                    .push_tag(b"SN", &seq.name)
+                    .push_tag(b"LN", &seq.length),
+            );
+        }
+    }
+    pub fn map_to_sam(
+        &self,
+        seq: &[u8],
+        qual: Option<&[u8]>,
+        name: Option<&[u8]>,
+        header: &HeaderView,
+        max_frag_len: Option<usize>,
+        extra_flags: Option<Vec<u64>>,
+    ) -> Result<Vec<Record>, &'static str> {
+        // Make sure index is set
+        if !self.has_index() {
+            return Err("No index");
+        }
+
+        // Make sure sequence is not empty
+        if seq.is_empty() {
+            return Err("Sequence is empty");
+        }
+
+        let query = Query::new(seq, qual, name);
+        // Number of results
+        let mut n_regs: i32 = 0;
+        let mut map_opt = self.mapopt.clone();
+
+        // immutable raw pointer to the index
+        let mi = &**self.idx.as_ref().unwrap().as_ref() as *const mm_ffi::mm_idx_t;
+
+        // TODO: other flags to consider:
+        // MM_F_NO_PRINT_2ND
+        // MM_F_SAM_HIT_ONLY (though this seems to be the default?)
+        //map_opt.flag |= mm_ffi::MM_F_OUT_SAM as i64;
+        //map_opt.flag |= mm_ffi::MM_F_CIGAR as i64;
+
+        // if max_frag_len is not None: map_opt.max_frag_len = max_frag_len
+        if let Some(max_frag_len) = max_frag_len {
+            map_opt.max_frag_len = max_frag_len as i32;
+        }
+
+        // if extra_flags is not None: map_opt.flag |= extra_flags
+        if let Some(extra_flags) = extra_flags {
+            for flag in extra_flags {
+                map_opt.flag |= flag as i64;
+            }
+        }
+
+        let mappings = BUF.with(|buf| {
+            let mm_reg = MaybeUninit::new(unsafe {
+                mm_ffi::mm_map(
+                    mi,
+                    query.inner.l_seq,
+                    query.inner.seq as *const libc::c_char,
+                    &mut n_regs,
+                    buf.borrow_mut().buf,
+                    &map_opt,
+                    query.inner.name,
+                )
+            });
+            // FIXFIX: mm_map should return unmapped SAM records but it
+            //  currently doesn't seem to work. To work around this we create the
+            // record manually
+            if (n_regs == 0) & ((map_opt.flag & mm_ffi::MM_F_SAM_HIT_ONLY as i64) == 0) {
+                return vec![query.as_unmapped_record()];
+            }
+
+            let mut mappings = Vec::with_capacity(n_regs as usize);
+
+            for i in 0..n_regs {
+                let sam_str = unsafe {
+                    let mut result: MaybeUninit<mm_ffi::kstring_t> = MaybeUninit::zeroed();
+                    let const_ptr = *mm_reg.as_ptr() as *const mm_ffi::mm_reg1_t;
+                    let km = km_init();
+                    mm_ffi::mm_write_sam2(
+                        result.as_mut_ptr(),
+                        mi,
+                        &query.inner as *const mm_ffi::mm_bseq1_t,
+                        0,
+                        i,
+                        1,
+                        &n_regs,
+                        &const_ptr,
+                        km,
+                        map_opt.flag,
+                    );
+                    km_destroy(km);
+                    CStr::from_ptr((*result.as_ptr()).s)
+                };
+                let record = Record::from_sam(header, sam_str.to_bytes()).unwrap();
+                mappings.push(record);
+            }
+            mappings
+        });
+        Ok(mappings)
+    }
+}
+
+pub fn mapping_to_record(
+    mapping: Option<&Mapping>,
+    seq: &[u8],
+    header: Header,
+    qual: Option<&[u8]>,
+    query_name: Option<&[u8]>,
+) -> Record {
+    let mut rec = Record::new();
+    let qname = query_name.unwrap_or(b"query");
+    // FIXFIX: there's probably a better way of setting a default value
+    // for the quality string
+    let qual = qual.map_or_else(|| vec![255u8; seq.len()], Vec::from);
+
+    let cigar: Option<CigarString> = mapping.and_then(|m| {
+        m.alignment
+            .as_ref()
+            .and_then(|aln| aln.cigar.as_ref())
+            .map(cigar_to_cigarstr)
+    });
+
+    rec.set(qname, cigar.as_ref(), seq, &qual[..]);
+    match mapping {
+        Some(m) => {
+            if m.strand == Strand::Reverse {
+                rec.set_reverse();
+            }
+            if !m.is_primary {
+                rec.set_secondary();
+            }
+            if m.is_supplementary {
+                rec.set_supplementary();
+            }
+            // TODO: set secondary/supplementary flags
+            rec.set_pos(m.target_start as i64);
+            rec.set_mapq(m.mapq as u8);
+            rec.set_mpos(-1);
+            // TODO: set tid from sequences listed in header
+            rec.set_mtid(-1);
+            rec.set_insert_size(0);
+            if let Some(Some(cs)) = m.alignment.as_ref().map(|a| &a.cs)
+                && let Ok(css) = CsString::from_str(cs)
+            {
+                let _ = rec.updateorsetcstag(&css);
+            } else if let Some(Some(md)) = m.alignment.as_ref().map(|a| &a.md) {
+                let _ = rec.push_aux(b"MD", Aux::String(md));
+            };
+        }
+        None => {
+            rec.set_unmapped();
+            rec.set_tid(-1);
+            rec.set_pos(-1);
+            rec.set_mapq(255);
+            rec.set_mpos(-1);
+            rec.set_mtid(-1);
+            rec.set_insert_size(-1);
+        }
+    };
+    // TODO: set AUX flags for cs/md if available*
+    rec
+}
+
+fn cigar_to_cigarstr(cigar: &Vec<(u32, u8)>) -> CigarString {
+    let op_vec: Vec<Cigar> = cigar
+        .to_owned()
+        .iter()
+        .map(|(len, op)| match op {
+            0 => Cigar::Match(*len),
+            1 => Cigar::Ins(*len),
+            2 => Cigar::Del(*len),
+            3 => Cigar::RefSkip(*len),
+            4 => Cigar::SoftClip(*len),
+            5 => Cigar::HardClip(*len),
+            6 => Cigar::Pad(*len),
+            7 => Cigar::Equal(*len),
+            8 => Cigar::Diff(*len),
+            _ => panic!("Unexpected cigar operation"),
+        })
+        .collect();
+    CigarString(op_vec)
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct SeqMetaData {
+    pub name: String,
+    pub length: u32,
+    pub is_alt: bool,
+}
+
+pub struct MMIndex {
+    pub inner: Arc<super::MmIdx>,
+}
+
+impl MMIndex {
+    pub fn n_seq(&self) -> u32 {
+        unsafe { (**self.inner).n_seq }
+    }
+
+    pub fn seqs(&self) -> Vec<SeqMetaData> {
+        let mut seqs: Vec<SeqMetaData> = Vec::with_capacity(self.n_seq() as usize);
+        for i in 0..self.n_seq() {
+            let _seq = unsafe { *(**self.inner).seq.offset(i as isize) };
+            // let c_str = unsafe { ffi::CStr::from_ptr(_seq.name) };
+            let c_str = unsafe { CStr::from_ptr(_seq.name) };
+            let rust_str = c_str.to_str().unwrap().to_string();
+            seqs.push(SeqMetaData {
+                name: rust_str,
+                length: _seq.len,
+                is_alt: _seq.is_alt != 0,
+            });
+        }
+        seqs
+    }
+
+    pub fn get_header(&self) -> Header {
+        let mut header = Header::new();
+        for seq in self.seqs() {
+            header.push_record(
+                HeaderRecord::new(b"SQ")
+                    .push_tag(b"SN", &seq.name)
+                    .push_tag(b"LN", &seq.length),
+            );
+        }
+        header
+    }
+}
+
+impl From<&Aligner<Built>> for MMIndex {
+    fn from(aligner: &Aligner<Built>) -> Self {
+        MMIndex {
+            inner: std::sync::Arc::clone(aligner.idx.as_ref().unwrap()),
+        }
+    }
+}
+
+#[cfg(test)]
+#[cfg(feature = "htslib")]
+mod tests {
+    use super::*;
+    use crate::Aligner;
+    use extended_htslib::bam::ext::BamRecordExtensions;
+    use extended_htslib::bam::{Read, Reader, Record, header::Header, record::Aux};
+    use libc::RTNLGRP_TUNNEL;
+    use rust_htslib::bam;
+    #[test]
+    fn testcs() {
+        let (aligner, _, header_view, _, seq, qual) = get_test_case("imperfect_read.fwd", false);
+        let result = aligner
+            .map(&seq, true, true, None, None, Some(b"test"))
+            .unwrap();
+        let mut records = Vec::new();
+        for hit in result {
+            let val = mapping_to_record(
+                Some(&hit),
+                &seq,
+                Header::from_template(&header_view),
+                Some(&qual),
+                Some(b"imperfect_read.fwd"),
+            );
+            records.push(val);
+        }
+        assert_eq!(
+            records.iter().next().unwrap().aux(b"cs"),
+            Ok(Aux::String(":34*gt:10*ca:6*ag:6*gt:33*tg:6")),
+            "Csdata is invalid"
+        );
+    }
+    #[test]
+    fn test_index() {
+        let aligner = Aligner::builder()
+            .with_index_threads(1)
+            .with_index("test_data/genome.fa", None)
+            .unwrap();
+
+        let idx = MMIndex::from(&aligner);
+        let seqs = idx.seqs();
+        assert_eq!(
+            seqs,
+            vec![
+                SeqMetaData {
+                    name: "chr1".to_string(),
+                    length: 1720u32,
+                    is_alt: false
+                },
+                SeqMetaData {
+                    name: "chr2".to_string(),
+                    length: 460u32,
+                    is_alt: false
+                },
+            ]
+        );
+
+        let header = idx.get_header();
+
+        let records = header.to_hashmap();
+        let observed = records.get("SQ").unwrap().first().unwrap();
+        assert_eq!(observed.get("SN").unwrap(), "chr1");
+        assert_eq!(observed.get("LN").unwrap(), "1720");
+    }
+
+    /// find all alignments for a given query
+    fn get_expected_records(query_name: &str, spliced: bool) -> Vec<Record> {
+        let sam_path = match spliced {
+            true => "test_data/cDNA_vs_genome.sam",
+            false => "test_data/gDNA_vs_genome.sam",
+        };
+        let mut reader = Reader::from_path(sam_path).unwrap();
+        let records: Vec<Record> = reader
+            .records()
+            .filter_map(|r| Some(r.unwrap()))
+            .filter(|r| String::from_utf8_lossy(r.qname()) == *query_name)
+            .collect();
+        records
+    }
+
+    /// Extract the sequence from the primary alignment
+    fn get_query_sequence(records: &Vec<Record>) -> (Vec<u8>, Vec<u8>) {
+        let (seq, qual) = records
+            .iter()
+            .find(|r| !(r.is_secondary() | r.is_supplementary()))
+            .map(|r| {
+                let mut seq = r.seq().as_bytes();
+                let mut qual = r.qual().to_vec();
+                if r.is_reverse() {
+                    seq = seq
+                        .iter()
+                        .rev()
+                        .map(|b| match b {
+                            b'A' => b'T',
+                            b'T' => b'A',
+                            b'G' => b'C',
+                            b'C' => b'G',
+                            _ => panic!("Invalid base"),
+                        })
+                        .collect();
+                    qual = qual.into_iter().rev().collect();
+                };
+                (seq, qual)
+            })
+            .unwrap();
+        (seq, qual)
+    }
+
+    fn get_test_case(
+        query_name: &str,
+        spliced: bool,
+    ) -> (
+        Aligner<Built>,
+        MMIndex,
+        HeaderView,
+        Vec<Record>,
+        Vec<u8>,
+        Vec<u8>,
+    ) {
+        let aligner = match spliced {
+            false => Aligner::builder()
+                .with_index_threads(1)
+                .with_cigar()
+                .with_index("test_data/genome.fa", None)
+                .unwrap(),
+
+            true => Aligner::builder()
+                .splice()
+                .with_index_threads(1)
+                .with_cigar()
+                .with_index("test_data/genome.fa", None)
+                .unwrap(),
+        };
+
+        let idx = MMIndex::from(&aligner);
+        let header = idx.get_header();
+        let header_view = HeaderView::from_header(&header);
+        // truth set from cli minimap
+        let expected_recs = get_expected_records(query_name, spliced);
+
+        // extract the query sequence from the primary record for this query
+        let (seq, qual) = get_query_sequence(&expected_recs);
+        let qual: Vec<u8> = qual.iter().map(|q| q + 33).collect();
+        (aligner, idx, header_view, expected_recs, seq, qual)
+    }
+
+    fn map_test_case(
+        query_name: &str,
+        spliced: bool,
+        extra_flags: Option<Vec<u64>>,
+    ) -> (Vec<Record>, Vec<Record>) {
+        let (aligner, _, header_view, expected, seq, qual) = get_test_case(query_name, spliced);
+        let observed = aligner
+            .map_to_sam(
+                &seq,
+                Some(&qual),
+                Some(query_name.as_bytes()),
+                &header_view,
+                None,
+                extra_flags,
+            )
+            .unwrap();
+        (observed, expected)
+    }
+
+    #[test]
+    fn test_fwd() {
+        let query_name = "perfect_read.fwd";
+        let (o, e) = map_test_case(query_name, false, None);
+        check_single_mapper(&e, &o);
+    }
+
+    #[test]
+    fn test_rev() {
+        let query_name = "perfect_read.rev";
+        let (o, e) = map_test_case(query_name, false, None);
+        check_single_mapper(&e, &o);
+    }
+
+    #[test]
+    fn test_mismatch() {
+        let query_name = "imperfect_read.fwd";
+        let (o, e) = map_test_case(query_name, false, None);
+        check_single_mapper(&e, &o);
+
+        let rec = o.first().unwrap();
+        let nm = rec.aux(b"NM").unwrap();
+        assert_eq!(nm, Aux::U8(5));
+    }
+
+    #[test]
+    fn test_aux_tag() {
+        let query_name = "imperfect_read.fwd";
+        let xtra_flags = vec![mm_ffi::MM_F_OUT_MD as u64];
+        let (o, e) = map_test_case(query_name, false, Some(xtra_flags));
+        let expected = e.first().unwrap();
+        let observed = o.first().unwrap();
+        if let (Ok(Aux::String(e_md)), Ok(Aux::String(o_md))) =
+            (expected.aux(b"MD"), observed.aux(b"MD"))
+        {
+            assert_eq!(o_md.as_bytes(), e_md.as_bytes())
+        } else {
+            panic!("Could not read MD tag");
+        }
+    }
+
+    #[test]
+    fn test_unmapped() {
+        let query_name = "unmappable_read";
+        let (o, e) = map_test_case(query_name, false, None);
+        check_single_mapper(&e, &o);
+        let rec = o.first().unwrap();
+        assert!(rec.is_unmapped());
+    }
+
+    #[test]
+    fn test_secondary() {
+        let query_name = "perfect_inv_duplicate";
+        let (o, e) = map_test_case(query_name, false, None);
+
+        assert_eq!(o.len(), 2); // expect a primary and secondary mapping
+        let o_fields: Vec<_> = o
+            .iter()
+            .map(|r| (r.tid(), r.pos(), r.is_secondary(), r.is_supplementary()))
+            .collect();
+        let e_fields: Vec<_> = e
+            .iter()
+            .map(|r| (r.tid(), r.pos(), r.is_secondary(), r.is_supplementary()))
+            .collect();
+        assert_eq!(
+            o_fields,
+            vec![(0, 540, false, false), (0, 720, true, false)]
+        );
+        assert_eq!(o_fields, e_fields);
+    }
+
+    #[test]
+    fn test_supplementary() {
+        let query_name = "split_read";
+        let (o, e) = map_test_case(query_name, false, None);
+
+        assert_eq!(o.len(), 2); // expect a primary and supplementary mapping
+        let o_fields: Vec<_> = o
+            .iter()
+            .map(|r| (r.tid(), r.pos(), r.is_secondary(), r.is_supplementary()))
+            .collect();
+        let e_fields: Vec<_> = e
+            .iter()
+            .map(|r| (r.tid(), r.pos(), r.is_secondary(), r.is_supplementary()))
+            .collect();
+        assert_eq!(o_fields, vec![(0, 0, false, false), (0, 820, false, true)]);
+        assert_eq!(o_fields, e_fields);
+    }
+
+    #[test]
+    fn test_spliced() {
+        let query_name = "cdna.fwd";
+        let (o, e) = map_test_case(query_name, true, None);
+        check_single_mapper(&e, &o);
+
+        let record = o.first().unwrap();
+
+        let ablocks: Vec<_> = record.aligned_block_pairs().collect();
+        println!("{ablocks:?}");
+        assert_eq!(
+            ablocks,
+            vec![
+                ([0, 100], [540, 640]),
+                ([100, 200], [900, 1000]),
+                ([200, 300], [1080, 1180]),
+                ([300, 400], [1260, 1360])
+            ]
+        );
+        let introns: Vec<_> = record.introns().collect();
+        assert_eq!(introns, vec![[640, 900], [1000, 1080], [1180, 1260]]);
+    }
+
+    #[test]
+    fn test_spliced_rev() {
+        let query_name = "cdna.rev";
+        let (o, e) = map_test_case(query_name, true, None);
+        check_single_mapper(&e, &o);
+    }
+
+    fn check_single_mapper(expected: &Vec<Record>, observed: &Vec<Record>) {
+        // TODO: compare the SAM strings
+        assert_eq!(expected.len(), observed.len());
+        let e = expected.first().unwrap();
+        let o = observed.first().unwrap();
+        assert_eq!(o.seq().as_bytes(), e.seq().as_bytes());
+
+        assert_eq!(o.cigar(), e.cigar());
+        assert_eq!(o.inner().core.pos, e.inner().core.pos);
+        assert_eq!(o.inner().core.mpos, e.inner().core.mpos);
+        assert_eq!(o.inner().core.mtid, e.inner().core.mtid);
+        assert_eq!(o.inner().core.tid, e.inner().core.tid);
+        // the bin attribute is associated with BAM format, so I don't think we need to set it
+        // assert_eq!(o.inner().core.bin, e.inner().core.bin);
+        assert_eq!(o.inner().core.qual, e.inner().core.qual);
+        assert_eq!(o.inner().core.l_extranul, e.inner().core.l_extranul);
+        assert_eq!(o.inner().core.flag, e.inner().core.flag);
+        assert_eq!(o.inner().core.l_qname, e.inner().core.l_qname);
+        assert_eq!(o.inner().core.n_cigar, e.inner().core.n_cigar);
+        assert_eq!(o.inner().core.l_qseq, e.inner().core.l_qseq);
+        assert_eq!(o.inner().core.isize_, e.inner().core.isize_);
+    }
+
+    #[test]
+    fn test_optional_fields() {
+        let query_name = "perfect_read.fwd";
+        let (aligner, _, header_view, _, seq, _qual) = get_test_case(query_name, false);
+
+        let observed = aligner
+            .map_to_sam(
+                &seq,
+                None,
+                Some(query_name.as_bytes()),
+                &header_view,
+                None,
+                None,
+            )
+            .unwrap();
+        let rec = observed.first().unwrap();
+        assert_eq!(rec.qual(), vec![255; seq.len()]);
+
+        let observed = aligner
+            .map_to_sam(&seq, None, None, &header_view, None, None)
+            .unwrap();
+        let rec = observed.first().unwrap();
+        assert_eq!(rec.qual(), vec![255; seq.len()]);
+        assert_eq!(rec.qname(), b"query");
+    }
+
+    #[test]
+    fn test_optional_fields_unmappable() {
+        let query_name = "unmappable_read";
+        let (aligner, _, header_view, _, seq, _qual) = get_test_case(query_name, false);
+        let observed = aligner
+            .map_to_sam(&seq, None, None, &header_view, None, None)
+            .unwrap();
+    }
+
+    #[test]
+    fn test_doctest() {
+        let aligner = Aligner::builder()
+            .with_cigar()
+            .with_index("test_data/genome.fa", None)
+            .unwrap();
+        let mut header = Header::new();
+        aligner.populate_header(&mut header);
+        let header_view = HeaderView::from_header(&header);
+
+        let records = aligner
+            .map_to_sam(
+                b"TACGCCACACGGGCTACACTCTCGCCTTCTCGTCTCAACTACGAGATGGACTGTCGGCCTAGAGGATCTAACACGAGAAGTACTTGCCGGCAAGCCCTAA",
+                Some(b"2222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222"),
+                Some(b"read1"),
+                &header_view, None, None)
+            .unwrap();
+
+        assert_eq!(records.len(), 1);
+        let record = records.first().unwrap();
+        assert_eq!((record.tid(), record.pos(), record.mapq()), (0, 180, 13));
+
+        let nm = record.aux(b"NM").unwrap();
+        assert_eq!(nm, Aux::U8(5));
+
+        // you can also map reads with no quality/name
+        let records = aligner
+            .map_to_sam(
+                b"TACGCCACACGGGCTACACTCTCGCCTTCTCGTCTCAACTACGAGATGGACTGTCGGCCTAGAGGATCTAACACGAGAAGTACTTGCCGGCAAGCCCTAA",
+                None, None,  &header_view, None, None)
+            .unwrap();
+
+        assert_eq!(records.len(), 1);
+        let record = records.first().unwrap();
+        assert_eq!((record.tid(), record.pos(), record.mapq()), (0, 180, 13));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@
 //! This crate has multiple create features available.
 //! * map-file - Enables the ability to map a file directly to a reference. Enabled by deafult
 //! * htslib - Provides an interface to minimap2 that returns rust_htslib::Records
+//! * extended-htslib - Provides an interface to minimap2 that returns extended_rusthtslib::Records and CS tag.
 //! * simde - Enables SIMD Everywhere library in minimap2
 //! * zlib-ng - Enables the use of zlib-ng for faster compression
 //! * curl - Enables curl for htslib
@@ -73,8 +74,9 @@ pub use minimap2_sys as ffi;
 
 #[cfg(feature = "map-file")]
 use needletail::parse_fastx_file;
-
-#[cfg(feature = "htslib")]
+#[cfg(feature = "extendedhtslib")]
+pub mod extendedhtslib;
+#[cfg(all(feature = "htslib", not(feature = "extendedhtslib")))]
 pub mod htslib;
 
 /// Alias for mm_mapop_t
@@ -389,7 +391,11 @@ impl Aligner<()> {
         };
 
         unsafe {
-            let ret = minimap2_sys::mm_set_opt(std::ptr::null(), &mut aligner.idxopt, &mut aligner.mapopt);
+            let ret = minimap2_sys::mm_set_opt(
+                std::ptr::null(),
+                &mut aligner.idxopt,
+                &mut aligner.mapopt,
+            );
             assert_eq!(ret, 0);
         }
 
@@ -794,7 +800,7 @@ where
         // Large reference genomes are automatically split into parts based on batch_size
         let mut idx_parts = Vec::new();
         let mut first_idx = None;
-        
+
         unsafe {
             // Read all index parts in a loop, just like C minimap2 does
             // This handles both single-part and multi-part indexes transparently
@@ -803,11 +809,11 @@ where
                     &mut *idx_reader as *mut mm_idx_reader_t,
                     self.threads as libc::c_int,
                 );
-                
+
                 if idx_part.is_null() {
                     break; // No more parts to read
                 }
-                
+
                 if first_idx.is_none() {
                     // Use the first part for mapping option updates and API compatibility
                     mm_mapopt_update(&mut self.mapopt, idx_part);
@@ -821,16 +827,16 @@ where
                     idx_parts.push(Arc::new(idx_part.into()));
                 }
             }
-            
+
             // Close the reader after reading all parts
             mm_idx_reader_close(idx_reader);
         }
-        
+
         // Ensure we got at least one index part
         if first_idx.is_none() {
             return Err("Failed to read index - no parts found");
         }
-        
+
         self.idx = first_idx;
         self.idx_parts = idx_parts;
 
@@ -1197,7 +1203,7 @@ impl Aligner<Built> {
 
         let mappings = BUF.with_borrow_mut(|buf| {
             let mut all_mappings = Vec::new();
-            
+
             // Map against all index parts transparently
             // For single-part indexes, this will iterate once
             // For multi-part indexes, this will iterate over all parts
@@ -1216,283 +1222,284 @@ impl Aligner<Built> {
 
                 let mut mappings = Vec::with_capacity(n_regs as usize);
 
-            let km: *mut libc::c_void = unsafe { mm_tbuf_get_km(buf.get_buf()) };
+                let km: *mut libc::c_void = unsafe { mm_tbuf_get_km(buf.get_buf()) };
 
-            for i in 0..n_regs {
-                unsafe {
-                    let mm_reg1_mut_ptr = (*mm_reg.as_ptr()).offset(i as isize);
-                    let mm_reg1_const_ptr = mm_reg1_mut_ptr as *const mm_reg1_t;
-                    let reg: mm_reg1_t = *mm_reg1_mut_ptr;
+                for i in 0..n_regs {
+                    unsafe {
+                        let mm_reg1_mut_ptr = (*mm_reg.as_ptr()).offset(i as isize);
+                        let mm_reg1_const_ptr = mm_reg1_mut_ptr as *const mm_reg1_t;
+                        let reg: mm_reg1_t = *mm_reg1_mut_ptr;
 
-                    let idx = &**idx_part.as_ref();
+                        let idx = &**idx_part.as_ref();
 
-                    let contig = {
-                        let seqs = (*idx).seq;
-                        let entry = seqs.offset(reg.rid as isize);
-                        let name_ptr: *const libc::c_char = (*entry).name;
-                        std::ffi::CStr::from_ptr(name_ptr)
-                    };
-
-                    // TODO: deprecate?
-                    let _target_len = {
-                        let seqs = (*idx).seq;
-                        let entry = seqs.offset(reg.rid as isize);
-                        (*entry).len as i32
-                    };
-
-                    let is_primary = reg.parent == reg.id && (reg.sam_pri() > 0);
-                    let is_supplementary = (reg.parent == reg.id) && (reg.sam_pri() == 0);
-                    let is_spliced = reg.is_spliced() != 0;
-                    let trans_strand = if let Some(extra) = reg.p.as_ref() {
-                        match extra.trans_strand() {
-                            1 => Some(Strand::Forward),
-                            2 => Some(Strand::Reverse),
-                            _ => None,
-                        }
-                    } else {
-                        None
-                    };
-
-                    // todo holy heck this code is ugly
-                    let alignment = if !reg.p.is_null() {
-                        let p = &*reg.p;
-
-                        // calculate the edit distance
-                        let nm = reg.blen - reg.mlen + p.n_ambi() as i32;
-                        let n_cigar = p.n_cigar;
-
-                        // Create a vector of the cigar blocks
-                        let (cigar, cigar_str) = if n_cigar > 0 {
-                            let mut cigar = p
-                                .cigar
-                                .as_slice(n_cigar as usize)
-                                .to_vec()
-                                .iter()
-                                .map(|c| ((c >> 4), (c & 0xf) as u8)) // unpack the length and op code
-                                .collect::<Vec<(u32, u8)>>();
-
-                            // Fix for adding in soft clipping cigar strings
-                            // Taken from minimap2 write_sam_cigar function
-                            // clip_len[0] = r->rev? qlen - r->qe : r->qs;
-                            // clip_len[1] = r->rev? r->qs : qlen - r->qe;
-
-                            let clip_len0 = if reg.rev() != 0 {
-                                seq.len() as i32 - reg.qe
-                            } else {
-                                reg.qs
-                            };
-
-                            let clip_len1 = if reg.rev() != 0 {
-                                reg.qs
-                            } else {
-                                seq.len() as i32 - reg.qe
-                            };
-
-                            let mut cigar_str = cigar
-                                .iter()
-                                .map(|(len, code)| {
-                                    let cigar_char = match code {
-                                        0 => "M",
-                                        1 => "I",
-                                        2 => "D",
-                                        3 => "N",
-                                        4 => "S",
-                                        5 => "H",
-                                        6 => "P",
-                                        7 => "=",
-                                        8 => "X",
-                                        _ => panic!("Invalid CIGAR code {code}"),
-                                    };
-                                    format!("{len}{cigar_char}")
-                                })
-                                .collect::<Vec<String>>()
-                                .join("");
-
-                            // int clip_char = (((sam_flag&0x800) || ((sam_flag&0x100) && (opt_flag&MM_F_SECONDARY_SEQ))) &&
-                            // !(opt_flag&MM_F_SOFTCLIP)) ? 'H' : 'S';
-
-                            // let clip_char = if (reg.flag & 0x800 != 0) || ((reg.flag & 0x100 != 0) && (map_opt.flag & 0x100 != 0)) && (map_opt.flag & 0x4 == 0) {
-                            // 'H'
-                            // } else {
-                            // 'S'
-                            // };
-
-                            // TODO: Support hard clipping
-                            let clip_char = 'S';
-
-                            // Pre and append soft clip identifiers to start and end
-                            if clip_len0 > 0 {
-                                cigar_str = format!("{}{}{}", clip_len0, clip_char, cigar_str);
-                                if self.cigar_clipping {
-                                    cigar.insert(0, (clip_len0 as u32, 4_u8));
-                                }
-                            }
-
-                            if clip_len1 > 0 {
-                                cigar_str = format!("{}{}{}", cigar_str, clip_len1, clip_char);
-                                if self.cigar_clipping {
-                                    cigar.push((clip_len1 as u32, 4_u8));
-                                }
-                            }
-
-                            (Some(cigar), Some(cigar_str))
-                        } else {
-                            (None, None)
+                        let contig = {
+                            let seqs = (*idx).seq;
+                            let entry = seqs.offset(reg.rid as isize);
+                            let name_ptr: *const libc::c_char = (*entry).name;
+                            std::ffi::CStr::from_ptr(name_ptr)
                         };
 
-                        let (cs_str, md_str) = if cs || md {
-                            let cs_str = if cs {
-                                let mut cs_string: *mut libc::c_char = std::ptr::null_mut();
-                                let mut m_cs_string: libc::c_int = 0i32;
+                        // TODO: deprecate?
+                        let _target_len = {
+                            let seqs = (*idx).seq;
+                            let entry = seqs.offset(reg.rid as isize);
+                            (*entry).len as i32
+                        };
 
-                                // This solves a weird segfault...
-                                // let km = km_init();
+                        let is_primary = reg.parent == reg.id && (reg.sam_pri() > 0);
+                        let is_supplementary = (reg.parent == reg.id) && (reg.sam_pri() == 0);
+                        let is_spliced = reg.is_spliced() != 0;
+                        let trans_strand = if let Some(extra) = reg.p.as_ref() {
+                            match extra.trans_strand() {
+                                1 => Some(Strand::Forward),
+                                2 => Some(Strand::Reverse),
+                                _ => None,
+                            }
+                        } else {
+                            None
+                        };
 
-                                /*
-                                let _cs_len = mm_gen_cs(
-                                    km,
-                                    &mut cs_string,
-                                    &mut m_cs_string,
-                                    idx,
-                                    mm_reg1_const_ptr,
-                                    seq.as_ptr() as *const libc::c_char,
-                                    true.into(),
-                                );
+                        // todo holy heck this code is ugly
+                        let alignment = if !reg.p.is_null() {
+                            let p = &*reg.p;
 
-                                let _cs_string = std::ffi::CStr::from_ptr(cs_string)
-                                    .to_str()
-                                    .unwrap()
-                                    .to_string();
-                                */
+                            // calculate the edit distance
+                            let nm = reg.blen - reg.mlen + p.n_ambi() as i32;
+                            let n_cigar = p.n_cigar;
 
-                                let _cs_len = {
-                                    mm_gen_cs(
+                            // Create a vector of the cigar blocks
+                            let (cigar, cigar_str) = if n_cigar > 0 {
+                                let mut cigar = p
+                                    .cigar
+                                    .as_slice(n_cigar as usize)
+                                    .to_vec()
+                                    .iter()
+                                    .map(|c| ((c >> 4), (c & 0xf) as u8)) // unpack the length and op code
+                                    .collect::<Vec<(u32, u8)>>();
+
+                                // Fix for adding in soft clipping cigar strings
+                                // Taken from minimap2 write_sam_cigar function
+                                // clip_len[0] = r->rev? qlen - r->qe : r->qs;
+                                // clip_len[1] = r->rev? r->qs : qlen - r->qe;
+
+                                let clip_len0 = if reg.rev() != 0 {
+                                    seq.len() as i32 - reg.qe
+                                } else {
+                                    reg.qs
+                                };
+
+                                let clip_len1 = if reg.rev() != 0 {
+                                    reg.qs
+                                } else {
+                                    seq.len() as i32 - reg.qe
+                                };
+
+                                let mut cigar_str = cigar
+                                    .iter()
+                                    .map(|(len, code)| {
+                                        let cigar_char = match code {
+                                            0 => "M",
+                                            1 => "I",
+                                            2 => "D",
+                                            3 => "N",
+                                            4 => "S",
+                                            5 => "H",
+                                            6 => "P",
+                                            7 => "=",
+                                            8 => "X",
+                                            _ => panic!("Invalid CIGAR code {code}"),
+                                        };
+                                        format!("{len}{cigar_char}")
+                                    })
+                                    .collect::<Vec<String>>()
+                                    .join("");
+
+                                // int clip_char = (((sam_flag&0x800) || ((sam_flag&0x100) && (opt_flag&MM_F_SECONDARY_SEQ))) &&
+                                // !(opt_flag&MM_F_SOFTCLIP)) ? 'H' : 'S';
+
+                                // let clip_char = if (reg.flag & 0x800 != 0) || ((reg.flag & 0x100 != 0) && (map_opt.flag & 0x100 != 0)) && (map_opt.flag & 0x4 == 0) {
+                                // 'H'
+                                // } else {
+                                // 'S'
+                                // };
+
+                                // TODO: Support hard clipping
+                                let clip_char = 'S';
+
+                                // Pre and append soft clip identifiers to start and end
+                                if clip_len0 > 0 {
+                                    cigar_str = format!("{}{}{}", clip_len0, clip_char, cigar_str);
+                                    if self.cigar_clipping {
+                                        cigar.insert(0, (clip_len0 as u32, 4_u8));
+                                    }
+                                }
+
+                                if clip_len1 > 0 {
+                                    cigar_str = format!("{}{}{}", cigar_str, clip_len1, clip_char);
+                                    if self.cigar_clipping {
+                                        cigar.push((clip_len1 as u32, 4_u8));
+                                    }
+                                }
+
+                                (Some(cigar), Some(cigar_str))
+                            } else {
+                                (None, None)
+                            };
+
+                            let (cs_str, md_str) = if cs || md {
+                                let cs_str = if cs {
+                                    let mut cs_string: *mut libc::c_char = std::ptr::null_mut();
+                                    let mut m_cs_string: libc::c_int = 0i32;
+
+                                    // This solves a weird segfault...
+                                    // let km = km_init();
+
+                                    /*
+                                    let _cs_len = mm_gen_cs(
                                         km,
                                         &mut cs_string,
                                         &mut m_cs_string,
                                         idx,
                                         mm_reg1_const_ptr,
-                                        seq.as_ptr() as *const _,
-                                        1,
-                                    )
-                                };
-                                let _cs = {
-                                    let s =
-                                        CStr::from_ptr(cs_string).to_string_lossy().into_owned();
-                                    libc::free(cs_string as *mut _);
-                                    s
+                                        seq.as_ptr() as *const libc::c_char,
+                                        true.into(),
+                                    );
+
+                                    let _cs_string = std::ffi::CStr::from_ptr(cs_string)
+                                        .to_str()
+                                        .unwrap()
+                                        .to_string();
+                                    */
+
+                                    let _cs_len = {
+                                        mm_gen_cs(
+                                            km,
+                                            &mut cs_string,
+                                            &mut m_cs_string,
+                                            idx,
+                                            mm_reg1_const_ptr,
+                                            seq.as_ptr() as *const _,
+                                            1,
+                                        )
+                                    };
+                                    let _cs = {
+                                        let s = CStr::from_ptr(cs_string)
+                                            .to_string_lossy()
+                                            .into_owned();
+                                        libc::free(cs_string as *mut _);
+                                        s
+                                    };
+
+                                    // libc::free(cs_string as *mut c_void);
+                                    // km_destroy(km);
+                                    Some(_cs)
+                                } else {
+                                    None
                                 };
 
-                                // libc::free(cs_string as *mut c_void);
-                                // km_destroy(km);
-                                Some(_cs)
+                                let md_str = if md {
+                                    // scratch-space pointers & lengths
+                                    let mut md_buf: *mut libc::c_char = std::ptr::null_mut();
+                                    let mut md_len: libc::c_int = 0;
+
+                                    // generate the MD tag into our ThreadBuffer’s km pool
+                                    let _written = {
+                                        mm_gen_MD(
+                                            km,
+                                            &mut md_buf,
+                                            &mut md_len,
+                                            idx,
+                                            mm_reg1_const_ptr,
+                                            seq.as_ptr() as *const _,
+                                        )
+                                    };
+
+                                    // turn it into a Rust String and free the C buffer
+                                    let md_string = {
+                                        let s = std::ffi::CStr::from_ptr(md_buf)
+                                            .to_string_lossy()
+                                            .into_owned();
+                                        libc::free(md_buf as *mut libc::c_void);
+                                        s
+                                    };
+
+                                    Some(md_string)
+                                } else {
+                                    None
+                                };
+
+                                (cs_str, md_str)
                             } else {
-                                None
+                                (None, None)
                             };
 
-                            let md_str = if md {
-                                // scratch-space pointers & lengths
-                                let mut md_buf: *mut libc::c_char = std::ptr::null_mut();
-                                let mut md_len: libc::c_int = 0;
-
-                                // generate the MD tag into our ThreadBuffer’s km pool
-                                let _written = {
-                                    mm_gen_MD(
-                                        km,
-                                        &mut md_buf,
-                                        &mut md_len,
-                                        idx,
-                                        mm_reg1_const_ptr,
-                                        seq.as_ptr() as *const _,
-                                    )
-                                };
-
-                                // turn it into a Rust String and free the C buffer
-                                let md_string = {
-                                    let s = std::ffi::CStr::from_ptr(md_buf)
-                                        .to_string_lossy()
-                                        .into_owned();
-                                    libc::free(md_buf as *mut libc::c_void);
-                                    s
-                                };
-
-                                Some(md_string)
-                            } else {
-                                None
-                            };
-
-                            (cs_str, md_str)
+                            Some(Alignment {
+                                nm,
+                                cigar,
+                                cigar_str,
+                                md: md_str,
+                                cs: cs_str,
+                                alignment_score: Some(p.dp_score as i32),
+                            })
                         } else {
-                            (None, None)
+                            None
                         };
 
-                        Some(Alignment {
-                            nm,
-                            cigar,
-                            cigar_str,
-                            md: md_str,
-                            cs: cs_str,
-                            alignment_score: Some(p.dp_score as i32),
-                        })
-                    } else {
-                        None
-                    };
+                        let target_name_arc = Arc::new(
+                            std::ffi::CStr::from_ptr(contig.as_ptr())
+                                .to_str()
+                                .unwrap()
+                                .to_string(),
+                        );
 
-                    let target_name_arc = Arc::new(
-                        std::ffi::CStr::from_ptr(contig.as_ptr())
-                            .to_str()
-                            .unwrap()
-                            .to_string(),
-                    );
+                        let target_len = {
+                            let seqs = (*idx).seq;
+                            let entry = seqs.offset(reg.rid as isize);
+                            (*entry).len as i32
+                        };
 
-                    let target_len = {
-                        let seqs = (*idx).seq;
-                        let entry = seqs.offset(reg.rid as isize);
-                        (*entry).len as i32
-                    };
+                        mappings.push(Mapping {
+                            target_name: Some(Arc::clone(&target_name_arc)),
+                            target_len,
+                            target_start: reg.rs,
+                            target_end: reg.re,
+                            target_id: reg.rid,
+                            query_name: query_name_arc.clone(),
+                            query_len: NonZeroI32::new(seq.len() as i32),
+                            query_start: reg.qs,
+                            query_end: reg.qe,
+                            strand: if reg.rev() == 0 {
+                                Strand::Forward
+                            } else {
+                                Strand::Reverse
+                            },
+                            match_len: reg.mlen,
+                            block_len: reg.blen,
+                            mapq: reg.mapq(),
+                            is_primary,
+                            is_supplementary,
+                            is_spliced,
+                            trans_strand,
+                            alignment,
+                            segment_id: 0, // Single-end mapping
+                        });
+                        libc::free(reg.p as *mut c_void);
+                    }
+                }
 
-                    mappings.push(Mapping {
-                        target_name: Some(Arc::clone(&target_name_arc)),
-                        target_len,
-                        target_start: reg.rs,
-                        target_end: reg.re,
-                        target_id: reg.rid,
-                        query_name: query_name_arc.clone(),
-                        query_len: NonZeroI32::new(seq.len() as i32),
-                        query_start: reg.qs,
-                        query_end: reg.qe,
-                        strand: if reg.rev() == 0 {
-                            Strand::Forward
-                        } else {
-                            Strand::Reverse
-                        },
-                        match_len: reg.mlen,
-                        block_len: reg.blen,
-                        mapq: reg.mapq(),
-                        is_primary,
-                        is_supplementary,
-                        is_spliced,
-                        trans_strand,
-                        alignment,
-                        segment_id: 0, // Single-end mapping
-                    });
-                    libc::free(reg.p as *mut c_void);
+                // Add mappings from this part to the overall result
+                all_mappings.extend(mappings);
+
+                // Free the mm_regs for this part
+                unsafe {
+                    let ptr: *mut mm_reg1_t = mm_reg.assume_init();
+                    let c_void_ptr: *mut c_void = ptr as *mut c_void;
+                    libc::free(c_void_ptr);
                 }
             }
-            
-            // Add mappings from this part to the overall result
-            all_mappings.extend(mappings);
-            
-            // Free the mm_regs for this part
-            unsafe {
-                let ptr: *mut mm_reg1_t = mm_reg.assume_init();
-                let c_void_ptr: *mut c_void = ptr as *mut c_void;
-                libc::free(c_void_ptr);
-            }
-        }
-        
-        all_mappings
-    });
+
+            all_mappings
+        });
 
         Ok(mappings)
     }
@@ -1741,14 +1748,16 @@ impl Aligner<Built> {
                                     let clip_char = 'S';
 
                                     if clip_len0 > 0 {
-                                        cigar_str = format!("{}{}{}", clip_len0, clip_char, cigar_str);
+                                        cigar_str =
+                                            format!("{}{}{}", clip_len0, clip_char, cigar_str);
                                         if self.cigar_clipping {
                                             cigar.insert(0, (clip_len0 as u32, 4_u8));
                                         }
                                     }
 
                                     if clip_len1 > 0 {
-                                        cigar_str = format!("{}{}{}", cigar_str, clip_len1, clip_char);
+                                        cigar_str =
+                                            format!("{}{}{}", cigar_str, clip_len1, clip_char);
                                         if self.cigar_clipping {
                                             cigar.push((clip_len1 as u32, 4_u8));
                                         }
@@ -2294,7 +2303,11 @@ mod tests {
         let mut mm_mapopt = MaybeUninit::uninit();
 
         unsafe {
-            let ret = mm_set_opt(std::ptr::null(), mm_idxopt.as_mut_ptr(), mm_mapopt.as_mut_ptr());
+            let ret = mm_set_opt(
+                std::ptr::null(),
+                mm_idxopt.as_mut_ptr(),
+                mm_mapopt.as_mut_ptr(),
+            );
             assert_eq!(ret, 0);
         };
     }
@@ -3369,7 +3382,15 @@ mod tests {
 
         // Test with CS and MD enabled
         let (mappings1, mappings2) = aligner
-            .map_pair(read1, read2, true, true, Some(500), None, Some(b"test_cs_md"))
+            .map_pair(
+                read1,
+                read2,
+                true,
+                true,
+                Some(500),
+                None,
+                Some(b"test_cs_md"),
+            )
             .unwrap();
 
         assert!(!mappings1.is_empty());


### PR DESCRIPTION
Hello,

I am the maintainer of https://docs.rs/extended-htslib/latest/extended_htslib/, an evolution of htslib taking advantage of CS and MD tag. Your implementation of minimap2 provides those tags and I was wondering if it was possible to allow use of extended htslib just as you did with htslib and provides a better linkage to CS/MD tag. I did some modifications on my pull requests to show an example (in test).

Thank you.