### PR TITLE
Fix cs md strlen overrun

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1341,6 +1341,16 @@ impl Aligner<Built> {
                         };
 
                         let (cs_str, md_str) = if cs || md {
+                            // mm_gen_cs_or_MD calls strlen() on the seq pointer.
+                            // Rust &[u8] is NOT NUL-terminated, so passing seq.as_ptr() can
+                            // cause __strlen_avx2 to read past the buffer and SEGV when the
+                            // next page is unmapped. Build a NUL-terminated copy once and
+                            // reuse it for both cs and md.
+                            let mut seq_nul: Vec<u8> = Vec::with_capacity(seq.len() + 1);
+                            seq_nul.extend_from_slice(seq);
+                            seq_nul.push(0);
+                            let seq_nul_ptr = seq_nul.as_ptr();
+
                             let cs_str = if cs {
                                 let mut cs_string: *mut libc::c_char = std::ptr::null_mut();
                                 let mut m_cs_string: libc::c_int = 0i32;
@@ -1372,7 +1382,7 @@ impl Aligner<Built> {
                                         &mut m_cs_string,
                                         idx,
                                         mm_reg1_const_ptr,
-                                        seq.as_ptr() as *const _,
+                                        seq_nul_ptr as *const _,
                                         1,
                                     )
                                 };
@@ -1416,7 +1426,7 @@ impl Aligner<Built> {
                                         &mut m_md_buf,
                                         idx,
                                         mm_reg1_const_ptr,
-                                        seq.as_ptr() as *const _,
+                                        seq_nul_ptr as *const _,
                                     )
                                 };
 
@@ -1461,7 +1471,7 @@ impl Aligner<Built> {
                     };
 
                     let target_name_arc = Arc::new(
-                        std::ffi::CStr::from_ptr(contig.as_ptr())
+                        contig
                             .to_str()
                             .unwrap()
                             .to_string(),
@@ -1782,6 +1792,16 @@ impl Aligner<Built> {
                                 };
 
                                 let (cs_str, md_str) = if cs || md {
+                                    // mm_gen_cs_or_MD calls strlen() on the seq pointer.
+                                    // Rust &[u8] is NOT NUL-terminated, so passing seq.as_ptr()
+                                    // can cause __strlen_avx2 to read past the buffer and SEGV
+                                    // when the next page is unmapped. Build a NUL-terminated
+                                    // copy once and reuse it for both cs and md.
+                                    let mut seq_nul: Vec<u8> = Vec::with_capacity(seq.len() + 1);
+                                    seq_nul.extend_from_slice(seq);
+                                    seq_nul.push(0);
+                                    let seq_nul_ptr = seq_nul.as_ptr();
+
                                     let cs_str = if cs {
                                         let mut cs_string: *mut libc::c_char = std::ptr::null_mut();
                                         let mut m_cs_string: libc::c_int = 0i32;
@@ -1793,7 +1813,7 @@ impl Aligner<Built> {
                                                 &mut m_cs_string,
                                                 idx,
                                                 mm_reg1_const_ptr,
-                                                seq.as_ptr() as *const _,
+                                                seq_nul_ptr as *const _,
                                                 1,
                                             )
                                         };
@@ -1830,7 +1850,7 @@ impl Aligner<Built> {
                                                 &mut m_md_buf,
                                                 idx,
                                                 mm_reg1_const_ptr,
-                                                seq.as_ptr() as *const _,
+                                                seq_nul_ptr as *const _,
                                             )
                                         };
 
@@ -1874,7 +1894,7 @@ impl Aligner<Built> {
                             };
 
                             let target_name_arc = Arc::new(
-                                std::ffi::CStr::from_ptr(contig.as_ptr())
+                                contig
                                     .to_str()
                                     .unwrap()
                                     .to_string(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1365,7 +1365,7 @@ impl Aligner<Built> {
                                     .to_string();
                                 */
 
-                                let _cs_len = {
+                                let cs_len = {
                                     mm_gen_cs(
                                         km,
                                         &mut cs_string,
@@ -1376,10 +1376,22 @@ impl Aligner<Built> {
                                         1,
                                     )
                                 };
+                                // Use the length returned by mm_gen_cs instead of strlen via
+                                // CStr::from_ptr. A non-NUL-terminated buffer near a page edge
+                                // causes __strlen_avx2 to read past the allocation and SIGSEGV.
                                 let _cs = {
-                                    let s =
-                                        CStr::from_ptr(cs_string).to_string_lossy().into_owned();
-                                    libc::free(cs_string as *mut _);
+                                    let s = if cs_len > 0 && !cs_string.is_null() {
+                                        let bytes = std::slice::from_raw_parts(
+                                            cs_string as *const u8,
+                                            cs_len as usize,
+                                        );
+                                        String::from_utf8_lossy(bytes).into_owned()
+                                    } else {
+                                        String::new()
+                                    };
+                                    if !cs_string.is_null() {
+                                        libc::free(cs_string as *mut _);
+                                    }
                                     s
                                 };
 
@@ -1391,28 +1403,38 @@ impl Aligner<Built> {
                             };
 
                             let md_str = if md {
-                                // scratch-space pointers & lengths
+                                // scratch-space pointers & capacity
                                 let mut md_buf: *mut libc::c_char = std::ptr::null_mut();
-                                let mut md_len: libc::c_int = 0;
+                                let mut m_md_buf: libc::c_int = 0;
 
-                                // generate the MD tag into our ThreadBuffer’s km pool
-                                let _written = {
+                                // generate the MD tag into our ThreadBuffer’s km pool;
+                                // return value is the length written.
+                                let md_len = {
                                     mm_gen_MD(
                                         km,
                                         &mut md_buf,
-                                        &mut md_len,
+                                        &mut m_md_buf,
                                         idx,
                                         mm_reg1_const_ptr,
                                         seq.as_ptr() as *const _,
                                     )
                                 };
 
-                                // turn it into a Rust String and free the C buffer
+                                // Use the returned length instead of strlen via CStr::from_ptr,
+                                // for the same page-overrun reason as cs above.
                                 let md_string = {
-                                    let s = std::ffi::CStr::from_ptr(md_buf)
-                                        .to_string_lossy()
-                                        .into_owned();
-                                    libc::free(md_buf as *mut libc::c_void);
+                                    let s = if md_len > 0 && !md_buf.is_null() {
+                                        let bytes = std::slice::from_raw_parts(
+                                            md_buf as *const u8,
+                                            md_len as usize,
+                                        );
+                                        String::from_utf8_lossy(bytes).into_owned()
+                                    } else {
+                                        String::new()
+                                    };
+                                    if !md_buf.is_null() {
+                                        libc::free(md_buf as *mut libc::c_void);
+                                    }
                                     s
                                 };
 
@@ -1764,7 +1786,7 @@ impl Aligner<Built> {
                                         let mut cs_string: *mut libc::c_char = std::ptr::null_mut();
                                         let mut m_cs_string: libc::c_int = 0i32;
 
-                                        let _cs_len = {
+                                        let cs_len = {
                                             mm_gen_cs(
                                                 km,
                                                 &mut cs_string,
@@ -1775,11 +1797,21 @@ impl Aligner<Built> {
                                                 1,
                                             )
                                         };
+                                        // Use returned length instead of strlen via
+                                        // CStr::from_ptr (page-overrun risk; see map()).
                                         let _cs = {
-                                            let s = CStr::from_ptr(cs_string)
-                                                .to_string_lossy()
-                                                .into_owned();
-                                            libc::free(cs_string as *mut _);
+                                            let s = if cs_len > 0 && !cs_string.is_null() {
+                                                let bytes = std::slice::from_raw_parts(
+                                                    cs_string as *const u8,
+                                                    cs_len as usize,
+                                                );
+                                                String::from_utf8_lossy(bytes).into_owned()
+                                            } else {
+                                                String::new()
+                                            };
+                                            if !cs_string.is_null() {
+                                                libc::free(cs_string as *mut _);
+                                            }
                                             s
                                         };
                                         Some(_cs)
@@ -1789,24 +1821,34 @@ impl Aligner<Built> {
 
                                     let md_str = if md {
                                         let mut md_buf: *mut libc::c_char = std::ptr::null_mut();
-                                        let mut md_len: libc::c_int = 0;
+                                        let mut m_md_buf: libc::c_int = 0;
 
-                                        let _written = {
+                                        let md_len = {
                                             mm_gen_MD(
                                                 km,
                                                 &mut md_buf,
-                                                &mut md_len,
+                                                &mut m_md_buf,
                                                 idx,
                                                 mm_reg1_const_ptr,
                                                 seq.as_ptr() as *const _,
                                             )
                                         };
 
+                                        // Use returned length instead of strlen via
+                                        // CStr::from_ptr (page-overrun risk; see map()).
                                         let md_string = {
-                                            let s = std::ffi::CStr::from_ptr(md_buf)
-                                                .to_string_lossy()
-                                                .into_owned();
-                                            libc::free(md_buf as *mut libc::c_void);
+                                            let s = if md_len > 0 && !md_buf.is_null() {
+                                                let bytes = std::slice::from_raw_parts(
+                                                    md_buf as *const u8,
+                                                    md_len as usize,
+                                                );
+                                                String::from_utf8_lossy(bytes).into_owned()
+                                            } else {
+                                                String::new()
+                                            };
+                                            if !md_buf.is_null() {
+                                                libc::free(md_buf as *mut libc::c_void);
+                                            }
                                             s
                                         };
                                         Some(md_string)


### PR DESCRIPTION
minimap2 C code calls `strlen()` on the seq pointer as the first operation in `mm_gen_cs_or_MD()`. Rust &[u8] slices are not NUL-terminated, so passing `seq.as_ptr()` directly causes __strlen_avx2 SIMD reads to walk past the
buffer into unmapped pages, triggering SIGSEGV (error 4).

Fix: build a NUL-terminated copy (seq_nul) once per read in the cs||md block and pass seq_nul_ptr to all mm_gen_cs/mm_gen_MD calls.

Also remove redundant CStr::from_ptr(contig.as_ptr()) that re-strlen an already-known-length CStr.

Tested on long-read scNanoATAC-seq data (13.8M reads, exit 0).