### PR TITLE
Fix typos in the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Also works. Otherwise directly cloning the aligner will Arc clone the internal i
 
 ## Features
 The following crate features are available:
-* map-file - Enables the ability to map a file directly to a reference. Enabled by deafult
+* map-file - Enables the ability to map a file directly to a reference. Enabled by default
 * htslib - Provides an interface to minimap2 that returns rust_htslib::Records
 * simde - Enables SIMD Everywhere library in minimap2
 * zlib-ng - Enables the use of zlib-ng for faster compression

--- a/minimap2-sys/README.md
+++ b/minimap2-sys/README.md
@@ -25,7 +25,7 @@ mm2-fast and minimap2 have diverged. At this point mm2-fast is no longer support
 ## Changelog
 ### 0.1.30 minimap2.2.30
 * Update to minimap2 2.30
-* Rename some functions for better multi-crate -sys compatabilities
+* Rename some functions for better multi-crate -sys compatibilities
 
 ### 0.1.29 minimap2.2.29
 * Update to minimap2 2.29


### PR DESCRIPTION
Fixes 2 spelling mistakes in the docs, found with `codespell`.

Prose only. No code identifiers, module paths, package names or proper nouns changed, and anything that was a valid word rather than a misspelling was left alone.